### PR TITLE
Fixes plugin failing to load on MP4 (+ lets MP4 use bonkstatemanager)

### DIFF
--- a/Bonk.as
+++ b/Bonk.as
@@ -72,9 +72,9 @@ void step() {
 	}
 	bonkTargetThresh = (bonkThresh + prev_speed * 1.5f);
 	mainBonkDetect = curr_acc > bonkTargetThresh;
-#if TMNEXT
+#if TMNEXT||MP4
 	bs.handleBonkCall(vis);
-#elif MP4||TURBO
+#elif TURBO
 	if (mainBonkDetect) bonk(curr_acc); // IsTurbo not reported by VehicleState wrapper
 #endif
 }

--- a/BonkStateManager.as
+++ b/BonkStateManager.as
@@ -7,7 +7,7 @@ class BonkStateManager {
         @bonkSound = Audio::LoadSample("bonk.wav");
     }
 
-#if TURBO||MP4
+#if TMNEXT||MP4
 
     int idx = 0;
 

--- a/BonkStateManager.as
+++ b/BonkStateManager.as
@@ -1,4 +1,3 @@
-#if TURBO||MP4
 class BonkStateManager {
     Audio::Sample@ pipeSound;
     Audio::Sample@ bonkSound; 
@@ -7,6 +6,8 @@ class BonkStateManager {
         @pipeSound = Audio::LoadSample("pipe.wav");
         @bonkSound = Audio::LoadSample("bonk.wav");
     }
+
+#if TURBO||MP4
 
     int idx = 0;
 
@@ -146,6 +147,5 @@ class BonkStateManager {
             (visState.RRGroundContact ? 1 : 0);
     }
 #endif
-
-}
 #endif
+}

--- a/BonkStateManager.as
+++ b/BonkStateManager.as
@@ -1,4 +1,4 @@
-
+#if TURBO||MP4
 class BonkStateManager {
     Audio::Sample@ pipeSound;
     Audio::Sample@ bonkSound; 
@@ -7,8 +7,6 @@ class BonkStateManager {
         @pipeSound = Audio::LoadSample("pipe.wav");
         @bonkSound = Audio::LoadSample("bonk.wav");
     }
-
-#if TMNEXT
 
     int idx = 0;
 
@@ -47,7 +45,11 @@ class BonkStateManager {
         vec3 v = visState.WorldVel;
         float vLen = v.Length();
 
+#if TMNEXT
         int wheelContactCount = notContactCheck(visState, EPlugSurfaceMaterialId::XXX_Null);
+#elif MP4||TURBO
+        int wheelContactCount = notContactCheck(visState);
+#endif
         wheelContactCountArr[idx] = wheelContactCount;
 
         if (pipeCountDown > 0) {
@@ -127,6 +129,7 @@ class BonkStateManager {
         return r;
     }
 
+#if TMNEXT
     int notContactCheck(CSceneVehicleVisState@ visState, EPlugSurfaceMaterialId surface) {
         return 
             (visState.FLGroundContactMaterial != surface ? 1 : 0) +
@@ -134,6 +137,15 @@ class BonkStateManager {
             (visState.RLGroundContactMaterial != surface ? 1 : 0) +
             (visState.RRGroundContactMaterial != surface ? 1 : 0);
     }
-
+#elif MP4
+    int notContactCheck(CSceneVehicleVisState@ visState) {
+        return
+            (visState.FLGroundContact ? 1 : 0) +
+            (visState.FRGroundContact ? 1 : 0) +
+            (visState.RLGroundContact ? 1 : 0) +
+            (visState.RRGroundContact ? 1 : 0);
+    }
 #endif
+
 }
+#endif

--- a/BonkStateManager.as
+++ b/BonkStateManager.as
@@ -48,7 +48,7 @@ class BonkStateManager {
 
 #if TMNEXT
         int wheelContactCount = notContactCheck(visState, EPlugSurfaceMaterialId::XXX_Null);
-#elif MP4||TURBO
+#elif MP4
         int wheelContactCount = notContactCheck(visState);
 #endif
         wheelContactCountArr[idx] = wheelContactCount;
@@ -129,6 +129,7 @@ class BonkStateManager {
         print(r);
         return r;
     }
+#endif
 
 #if TMNEXT
     int notContactCheck(CSceneVehicleVisState@ visState, EPlugSurfaceMaterialId surface) {
@@ -146,6 +147,5 @@ class BonkStateManager {
             (visState.RLGroundContact ? 1 : 0) +
             (visState.RRGroundContact ? 1 : 0);
     }
-#endif
 #endif
 }

--- a/Util.as
+++ b/Util.as
@@ -1,3 +1,4 @@
+#if TMNEXT
 bool isIceSurface(EPlugSurfaceMaterialId surface) {
   return (surface == CSceneVehicleVisState::EPlugSurfaceMaterialId::Ice ||
     surface == CSceneVehicleVisState::EPlugSurfaceMaterialId::RoadIce ||
@@ -32,3 +33,4 @@ bool isPlasticDirtOrGrass(EPlugSurfaceMaterialId surface) {
     isDirtSurface(surface) ||
     isGrassSurface(surface);
 }
+#endif


### PR DESCRIPTION
Title! We noticed this plugin was erroring out when loaded in MP4 despite being listed as compatible with MP4. Thankfully, it was a fairly straight-forward fix to get this working proper. We also noticed the behavior differed between MP4 and TM2020, in that bonkstatemanager and it's associated fluff was simply not active in MP4, but it was fairly straight-forward to fix up the minor incompatibility that was present. We're unable to test if this PR works in turbo (we don't own it) or that it still compiles in TM2020 (we don't have club access), but in theory both *should* work.

Additionally, we've wrapped Util.as in a `#if TMNEXT`, as the functionality within appears to be largely unused, and we're unaware of any external plugins that hook into it. It'd be fairly straight-forward to port the helper functions within to MP4, but it'd probably be far cleaner to rework it to work off arrays or dicts instead, which is out of this PR's scope.

To demonstrate that this does indeed work, here's a short video with audio showing the plugin working, and behavior specific to bonkstatemanager (the pipe sound effect) fully functional!

https://github.com/MisfitMaid/tm-bonk/assets/6356337/9e944a17-da5d-4205-91f2-dd82c83ee4c4

